### PR TITLE
Makes it compatible with Python 3.7 and below

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,8 @@ __pycache__/
 .pytest_cache
 
 Thumbs.db
+.DS_Store
+
+build/
+dist/
+jeanpaulstartui.egg-info/

--- a/README.fr-FR.md
+++ b/README.fr-FR.md
@@ -1,0 +1,225 @@
+# Jean Paul Start
+
+![](jeanpaulstartui.jpg)
+
+_L'enfer, c'est les .bats_
+
+- Execution de batches avec une syntaxe proche de celle d'[Ansible](http://docs.ansible.com/ansible/latest/user_guide/playbooks.html)
+
+- Fenêtre affichant les icônes correspondant aux batches
+
+- Extensibilité par plugins
+
+- Utilisé sous Windows, normalement compatible Linux
+
+## Installation
+
+````bash
+pip install git+https://github.com/Arubinu/jeanpaulstart.git
+````
+
+## Batches
+
+Un batch décrit au format YAML un environnement (à travers des variables), puis des actions à executer
+
+Exemple basique :
+
+````yaml
+---
+name: Jean Bauchefort
+icon_path: $ENVIRONMENT/_config/jeanpaulstart/icons/jean-bauchefort.png
+tags:
+  - production
+environment:
+  PYTHONPATH:
+    - C:\cube\python\Lib\site-packages
+    - R:\deploy\cube
+tasks:
+  - name: Running application
+    raw:
+      command: python -m jeanbauchefortui
+...
+````
+
+Pour un exemple plus complet, regarder [example-batch.yml](example-batch.yml)
+
+## Ligne de commande
+
+- Il est possible d'appeler un batch en ligne de commande 
+
+````bash
+python -m jeanpaulstart --filepath /path/to/a/batch.yml
+````
+
+- Il est possible d'executer un batch au format JSON sérialisé (peu commun)
+
+_L'utilisation du flag `--not-normalized` est conseillée_
+
+````bash
+python -m jeanpaulstart --not-normalized --json {"name": "3DS Max", ... }
+````
+
+## Interface Graphique
+
+Il existe une version PySide de Jean-Paul Start
+
+Elle se base sur les dossiers contenant des batches, et un fichier de configuration associant les noms d'utilisateurs (obtenus avec `getpass.getuser()`) aux tags présents dans les batches
+
+### Lancement
+
+Il suffit d'appeler le module `jeanpaulstartui`
+
+````bash
+python -m jeanpaulstartui --batches /path/to/a/batch/folder;/path/to/another/folder --tags /path/to/user-tags.yml
+````
+
+### User Tags
+
+Le fichier user tags représente au format YAML l'association de nom d'utilisateurs à des tags
+
+Exemple
+
+````yaml
+---
+production:
+  - jp.sartre
+  - p.deproges
+
+graphist_base:
+  - y.montand
+  - j.hallyday
+
+rigging:
+  - s.weaver
+  - j.rochefort
+...
+````
+
+Ainsi, les batches portant les tags 'production' apparaitront pour l'utilisateur `jp.sartre`
+
+- Il est possible de référencer un groupe dans un autre groupe en utilisant le caractère spécial `$`
+
+````yaml
+everyone:
+  - $production
+  - $graphist_base
+  - $rigging
+  - m.polnareff
+...
+````
+
+## Commandes disponibles
+
+Les commandes disponibles sont appelées tâches
+
+L'execution de chaque tâche est décrite dans un module python du package `jeanpaulstart.tasks`
+
+Ces modules sont listés au démarrage de Jean-Paul Start, s'ils répondent aux exigences du plugin-loader, deviennent disponible lors de l'execution des batches
+
+### Copy
+
+Permet de copier un fichier
+
+Si la destination existe, et `force: no`, aucune action n'est effectuée
+
+````yaml
+- name: Name of task
+  copy:
+    src: /path/to/source.ext
+    dest: /path/to/destination.ext
+    force: [yes|no]
+```` 
+
+### File
+
+Créé un fichier ou un dossier
+
+````yaml
+- name: Name of task
+  file:
+    path: /path/to/file
+    state: [directory|file]
+````
+
+### Include Tasks
+
+Permet d'excuter un batch
+
+L'environnement courant est passé au batch appelé, les modifications faites à l'environnement par le batch appelé ne sont pas conservées dans les tâches suivantes
+
+````yaml
+- name: Name
+  include_tasks:
+    file: path/to/batch/file.yml
+```` 
+
+### Ini File
+
+Permet de modifier un fichier .ini
+
+````yaml
+- name: Task Name
+  ini_file:
+    src: /path/to/ini/file.ini
+    state: [present|absent]
+    section: sectionName
+    option: optionName
+    value: valueValue
+````
+
+### Pip
+
+Execute la commande `pip install`
+
+Le paramètre `state` est facultatif, il vaut `present` par défaut
+
+````yaml
+- name: Task Name
+  pip:
+      name: PySide
+      state: [present|forcereinstall]
+````
+
+````yaml
+- name: Task Name
+  pip:
+      name: git+http://some/url.git
+````
+
+### Raw
+
+Execute une commande dans le terminal
+
+Le paramètre `async` execute la commande dans un processus enfant, sans interrompre l'execution (`Popen()`) (facultatif)
+Le paramètre `open_terminal` ouvre un nouveau terminal (facultatif)
+
+`async` vaut `True` par défaut, `open_terminal` vaut `False` par défaut
+
+````yaml
+- name: Launch djv_view
+  raw: 
+    command: "\"C:\\Program Files\\djv-1.1.0-Windows-64\\bin\\djv_view.exe\""
+    async:[yes|no]
+    open_terminal:[yes|no]
+````
+
+### Template
+
+Copie un fichier template au format [Jinja2](http://jinja.pocoo.org/docs/2.10/), en parsant les variables d'environnement
+
+````yaml
+- name: Task Name
+  template:
+    src: /path/to/source.ext.j2
+    dest: /path/to/dest.ext
+    force: [yes|no]
+````
+
+### Url
+
+Ouvre l'url donnée, dans le navigateur par défaut
+
+````yaml
+- name: Task Name
+  url: http://some.url/
+````

--- a/README.md
+++ b/README.md
@@ -1,15 +1,19 @@
 # Jean Paul Start
 
-L'enfer, c'est les .bats
+![](jeanpaulstartui.jpg)
 
-_Jean-Paul Start is verbose about plugin loading, batch loading and parsing, task execution, ..._
+_Hell is the .bats_
 
-_Be sure to set your logging level to `INFO` if needed_ 
+- Jean-Paul Start is verbose about plugin loading, batch loading and parsing, task execution, ...
+
+- Be sure to set your logging level to `INFO` if needed
+
+*Read this in other languages: [Français](README.fr-FR.md) (by sayanel@github).*
 
 ## Installation
 
 ````bash
-pip install git+https://github.com/cube-creative/jeanpaulstart.git
+pip install git+https://github.com/Arubinu/jeanpaulstart.git
 ````
 
 ## Usage as a CLI

--- a/jeanpaulstart/api.py
+++ b/jeanpaulstart/api.py
@@ -1,5 +1,6 @@
 from .constants import *
-import batch as _batch
+from . import batch as _batch
+#import batch as _batch
 from .executor import Executor, run_batch
 from . import plugin_loader as _plugin_loader
 

--- a/jeanpaulstart/batch/batch.py
+++ b/jeanpaulstart/batch/batch.py
@@ -2,8 +2,8 @@ import logging
 from jeanpaulstart import parser
 from jeanpaulstart.constants import *
 from jeanpaulstart.environment import parse
-from validator import validate
-from normalizer import normalize
+from .validator import validate
+from .normalizer import normalize
 
 
 class Batch(object):

--- a/jeanpaulstart/batch/loader.py
+++ b/jeanpaulstart/batch/loader.py
@@ -1,4 +1,4 @@
-from batch import Batch
+from .batch import Batch
 from jeanpaulstart import tags
 from jeanpaulstart import parser
 from jeanpaulstart.constants import *

--- a/jeanpaulstart/batch/normalizer.py
+++ b/jeanpaulstart/batch/normalizer.py
@@ -1,5 +1,5 @@
 import logging
-from task import Task
+from .task import Task
 from jeanpaulstart.constants import *
 from jeanpaulstart import plugin_loader
 
@@ -46,7 +46,7 @@ def _when(task_data):
 
 
 def _prepare_task_data(task_data):
-    command_name = task_data.keys()[1]
+    command_name = list(task_data.keys())[1]
 
     splitted = {
         'name': task_data['name'],

--- a/jeanpaulstart/batch/validator.py
+++ b/jeanpaulstart/batch/validator.py
@@ -33,7 +33,7 @@ def _validate_tags(data):
 
 
 def _validate_task(task_data):
-    command_name = task_data.keys()[1]
+    command_name = list(task_data.keys())[1]
     task_plugin = plugin_loader.loaded_plugins.get(command_name, None)
 
     if not task_plugin:

--- a/jeanpaulstart/environment.py
+++ b/jeanpaulstart/environment.py
@@ -48,7 +48,7 @@ def _parse_from_dict(dict_):
     for key, value in dict_.items():
         key = parse(key)
         if key == 'async':
-            key = 'async_on'
+            key = 'async_'
 
         if isinstance(value, list):
             parsed_dict[key] = [parse(item) for item in value]

--- a/jeanpaulstart/environment.py
+++ b/jeanpaulstart/environment.py
@@ -47,6 +47,8 @@ def _parse_from_dict(dict_):
     parsed_dict = dict()
     for key, value in dict_.items():
         key = parse(key)
+        if key == 'async':
+            key = 'async_on'
 
         if isinstance(value, list):
             parsed_dict[key] = [parse(item) for item in value]

--- a/jeanpaulstart/executor.py
+++ b/jeanpaulstart/executor.py
@@ -1,8 +1,8 @@
 import os
 import logging
-import environment
-import plugin_loader
-from constants import *
+from . import environment
+from . import plugin_loader
+from .constants import *
 
 
 def _apply_(task):

--- a/jeanpaulstart/parser.py
+++ b/jeanpaulstart/parser.py
@@ -32,7 +32,7 @@ class _OrderedDictYAMLLoader(yaml.Loader):
             key = self.construct_object(key_node, deep=deep)
             try:
                 hash(key)
-            except TypeError, exc:
+            except TypeError as exc:
                 raise yaml.constructor.ConstructorError(
                     'while constructing a mapping',
                     node.start_mark,

--- a/jeanpaulstart/plugin_loader.py
+++ b/jeanpaulstart/plugin_loader.py
@@ -3,7 +3,7 @@ import imp
 import logging
 from glob import glob
 from collections import OrderedDict
-from constants import *
+from .constants import *
 
 
 loaded_plugins = OrderedDict()
@@ -79,7 +79,7 @@ class Loader(object):
             status = self.validate(plugin)
 
             if status is not OK:
-                logging.warn("Could not validate plugin : '{plugin_name}.py' ({status})".format(
+                logging.warning("Could not validate plugin : '{plugin_name}.py' ({status})".format(
                     plugin_name=plugin_name,
                     status=status
                 ))
@@ -88,7 +88,7 @@ class Loader(object):
             command_name = plugin.TASK_COMMAND
 
             if command_name in plugins.keys():
-                logging.warn("Skipping plugin '{plugin_name}.py' : command '{command_name}' already loaded".format(
+                logging.warning("Skipping plugin '{plugin_name}.py' : command '{command_name}' already loaded".format(
                     plugin_name=plugin_name,
                     command_name=command_name
                 ))
@@ -108,7 +108,7 @@ def init(plugin_folder=None, force=False):
         plugin_folder = os.path.expandvars('$PLUGIN_FOLDER')
 
     if plugin_folder == "$PLUGIN_FOLDER":
-        import tasks
+        from . import tasks
         plugin_folder=os.path.dirname(tasks.__file__)
 
     if loaded_plugins and not force:

--- a/jeanpaulstart/tasks/ini_file.py
+++ b/jeanpaulstart/tasks/ini_file.py
@@ -1,6 +1,9 @@
 import shutil
-from StringIO import StringIO
-from ConfigParser import ConfigParser, MissingSectionHeaderError
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
+from configparser import ConfigParser, MissingSectionHeaderError
 from jeanpaulstart import file_io
 from jeanpaulstart.constants import *
 

--- a/jeanpaulstart/tasks/raw.py
+++ b/jeanpaulstart/tasks/raw.py
@@ -12,13 +12,13 @@ def validate(user_data):
 
 def normalize_after_split(splitted):
     normalized = dict(splitted)
-    normalized['arguments']['async_on'] = splitted['arguments'].get('async_on', True)
+    normalized['arguments']['async_'] = splitted['arguments'].get('async_', True)
     normalized['arguments']['open_terminal'] = splitted['arguments'].get('open_terminal', False)
     return normalized
 
 
-def apply_(async_on, command, open_terminal):
-    if async_on:
+def apply_(async_, command, open_terminal):
+    if async_:
         if open_terminal:
             command = "start cmd /k " + command
             return system(command)

--- a/jeanpaulstart/tasks/raw.py
+++ b/jeanpaulstart/tasks/raw.py
@@ -12,13 +12,13 @@ def validate(user_data):
 
 def normalize_after_split(splitted):
     normalized = dict(splitted)
-    normalized['arguments']['async'] = splitted['arguments'].get('async', True)
+    normalized['arguments']['async_on'] = splitted['arguments'].get('async_on', True)
     normalized['arguments']['open_terminal'] = splitted['arguments'].get('open_terminal', False)
     return normalized
 
 
-def apply_(async, command, open_terminal):
-    if async:
+def apply_(async_on, command, open_terminal):
+    if async_on:
         if open_terminal:
             command = "start cmd /k " + command
             return system(command)

--- a/tests/tests_tasks/test_raw.py
+++ b/tests/tests_tasks/test_raw.py
@@ -58,7 +58,7 @@ class TestTaskRaw(unittest.TestCase):
 
     def test_normalize_without_async(self):
         expected = deepcopy(SPLITTED)
-        expected['arguments']['async'] = True
+        expected['arguments']['async_on'] = True
         expected['arguments']['open_terminal'] = False
 
         normalized = raw.normalize_after_split(deepcopy(SPLITTED))
@@ -69,7 +69,7 @@ class TestTaskRaw(unittest.TestCase):
         )
 
     def test_apply_not_async(self):
-        raw.apply_(async=False, command="command", open_terminal=False)
+        raw.apply_(async_on=False, command="command", open_terminal=False)
 
         self.assertEqual(
             self._mock_call_called,
@@ -80,7 +80,7 @@ class TestTaskRaw(unittest.TestCase):
         self.assertIsNone(self._mock_system_called)
 
     def test_apply_async_no_terminal(self):
-        raw.apply_(async=True, command="command", open_terminal=False)
+        raw.apply_(async_on=True, command="command", open_terminal=False)
 
         self.assertEqual(
             self._mock_popen_called,
@@ -91,7 +91,7 @@ class TestTaskRaw(unittest.TestCase):
         self.assertIsNone(self._mock_system_called)
 
     def test_apply_async_open_terminal(self):
-        raw.apply_(async=True, command="command", open_terminal=True)
+        raw.apply_(async_on=True, command="command", open_terminal=True)
 
         self.assertEqual(
             self._mock_system_called,

--- a/tests/tests_tasks/test_raw.py
+++ b/tests/tests_tasks/test_raw.py
@@ -58,7 +58,7 @@ class TestTaskRaw(unittest.TestCase):
 
     def test_normalize_without_async(self):
         expected = deepcopy(SPLITTED)
-        expected['arguments']['async_on'] = True
+        expected['arguments']['async_'] = True
         expected['arguments']['open_terminal'] = False
 
         normalized = raw.normalize_after_split(deepcopy(SPLITTED))
@@ -69,7 +69,7 @@ class TestTaskRaw(unittest.TestCase):
         )
 
     def test_apply_not_async(self):
-        raw.apply_(async_on=False, command="command", open_terminal=False)
+        raw.apply_(async_=False, command="command", open_terminal=False)
 
         self.assertEqual(
             self._mock_call_called,
@@ -80,7 +80,7 @@ class TestTaskRaw(unittest.TestCase):
         self.assertIsNone(self._mock_system_called)
 
     def test_apply_async_no_terminal(self):
-        raw.apply_(async_on=True, command="command", open_terminal=False)
+        raw.apply_(async_=True, command="command", open_terminal=False)
 
         self.assertEqual(
             self._mock_popen_called,
@@ -91,7 +91,7 @@ class TestTaskRaw(unittest.TestCase):
         self.assertIsNone(self._mock_system_called)
 
     def test_apply_async_open_terminal(self):
-        raw.apply_(async_on=True, command="command", open_terminal=True)
+        raw.apply_(async_=True, command="command", open_terminal=True)
 
         self.assertEqual(
             self._mock_system_called,


### PR DESCRIPTION
Hello,

I propose these corrections to make compatible Jean-Paul Start with the latest versions of Python (Python3.7) and PySide (PySide2).

There were different types of corrections:
  - Problems of internal imports to the project,
  - Change the exception syntax,
  - some type changes,
  - The term "async" which is now reserved.